### PR TITLE
Fix #3 -- add fzf args to `inter_fzf`

### DIFF
--- a/src/JLFzf.jl
+++ b/src/JLFzf.jl
@@ -23,7 +23,7 @@ function inter_fzf(in_str::String, args...)
         if length(args) == 0
             return read(pipeline(`$exe`, stdin = IOBuffer(in_str)), String) |> chomp
         else
-            return read(pipeline(`$exe $(join(args, " "))`, stdin = IOBuffer(in_str)), String) |> chomp
+            return read(pipeline(`$exe $(join(args, ' '))`, stdin = IOBuffer(in_str)), String) |> chomp
         end
     end
 end


### PR DESCRIPTION
Hello. I'd create the functionality for #3.

But my startup file similar to yours [sample](https://github.com/KristofferC/OhMyREPL.jl/issues/204#issuecomment-655912413) is not working (`<ctrl-f>` is not responsive) and I don't understand why.
```julia
import REPL
import REPL.LineEdit
using JLFzf
const mykeys_f = Dict{Any,Any}(
    "^f" => function (s,o,c)         
        b = JLFzf.inter_fzf(JLFzf.read_repl_hist());
        LineEdit.edit_insert(Base.active_repl.mistate, b)
    end,
)
const mykeys_r = Dict{Any,Any}(
    "^r" => function (s,o,c)
        b = JLFzf.inter_fzf(JLFzf.read_repl_hist(), "--tiebreak=index");
        LineEdit.edit_insert(Base.active_repl.mistate, b)
    end,                             
)
function customize_keys(repl)
    repl.interface = REPL.setup_interface(repl; extra_repl_keymap = [mykeys_f, mykeys_r])
    #repl.interface = REPL.setup_interface(repl; extra_repl_keymap = mykeys_f)                        
end                                                                                                   
                                                                                                      
atreplinit(customize_keys)
```