### PR TITLE
Improve `read_repl_hist()` and fix running `fzf`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,13 +5,14 @@ version = "0.1.0"
 
 [deps]
 Pipe = "b98c9c47-44ae-5843-9183-064241ee97a0"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 fzf_jll = "214eeab7-80f7-51ab-84ad-2988db7cef09"
 
 [compat]
-julia = "1"
 Pipe = "1.3.0"
 fzf_jll = "0.21.1"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/JLFzf.jl
+++ b/src/JLFzf.jl
@@ -3,8 +3,9 @@ module JLFzf
 import fzf_jll
 using Pipe
 import REPL
+import REPL.LineEdit
 
-export inter_fzf, read_repl_hist
+export inter_fzf, read_repl_hist, insert_history_to_repl
 
 """
     read_repl_hist()
@@ -13,11 +14,20 @@ Find corresponding history file, read it, split by history records
 and return resulted `Vector{String}` in reverse order.
 """
 function read_repl_hist()
-    rx = r"(^|\n)# time:[^\n]*\n# mode:[^\n]*\n"m
+    rx  = r"(^|\n)# time:[^\n]*\n"m
+    # markers for history modes, used by `insert_history_to_repl()`
+    rxj = r"^# mode: julia\n"m => ""
+    rxh = r"^# mode: help\n"m  => "?\n"
+    rxp = r"^# mode: pkg\n"m   => "]\n"
+    rxs = r"^# mode: shell\n"m => ";\n"
     @pipe open(REPL.find_hist_file()) |>
     read |> String |>
     replace(_, r"\n$" => "") |>           # remove last new line
     replace(_, r"^\t"m => "") |>          # remove leading tabs
+    replace(_, rxj) |>                    # replace mode with corresponding marker
+    replace(_, rxh) |>                    #
+    replace(_, rxp) |>                    #
+    replace(_, rxs) |>                    #
     split(_, rx, keepempty = false) |>    # split by history records
     reverse |> unique                     # keep unique entries
 end
@@ -47,6 +57,35 @@ Additional arguments `args` for `fzf` are allowed.
 """
 function inter_fzf(ary::AbstractArray, args...)
     inter_fzf(join(ary, '\0'), args...)
+end
+
+function edit_insert_and_state_transition(mistate, line, mode)
+    LineEdit.edit_insert(mistate, line)
+    iobuffer = LineEdit.buffer(mistate)
+    LineEdit.transition(mistate, Base.active_repl.interface.modes[mode]) do
+        prompt_state = LineEdit.state(mistate, Base.active_repl.interface.modes[mode])
+        prompt_state.input_buffer = copy(iobuffer)
+    end
+end
+
+"""
+    insert_history_to_repl(mistate, line)
+
+Paste found by `fzf` history `line` into REPL `mistate`.
+"""
+function insert_history_to_repl(mistate, line)
+    rxh = r"^\?\n"
+    rxp = r"^\]\n"
+    rxs = r"^;\n"
+    if occursin(rxh, line)
+        edit_insert_and_state_transition(mistate, replace(line, rxh => ""), 3)
+    elseif occursin(rxp, line)
+        edit_insert_and_state_transition(mistate, replace(line, rxp => ""), 6)
+    elseif occursin(rxs, line)
+        edit_insert_and_state_transition(mistate, replace(line, rxs => ""), 2)
+    else
+        LineEdit.edit_insert(mistate, line)
+    end
 end
 
 end

--- a/src/JLFzf.jl
+++ b/src/JLFzf.jl
@@ -2,38 +2,51 @@ module JLFzf
 
 import fzf_jll
 using Pipe
+import REPL
 
-export inter_fzf
+export inter_fzf, read_repl_hist
 
+"""
+    read_repl_hist()
+
+Find corresponding history file, read it, split by history records
+and return resulted `Vector{String}` in reverse order.
+"""
 function read_repl_hist()
-    @pipe open("~/.julia/logs/repl_history.jl" |> expanduser) |> read |> String |> 
-    replace(_, "\t" => "") |> #remove tabs
-    split(_, "\n") |> #split by new lines
-    filter(x->!occursin("#", x), _) |> #remove comments lines end
-    unique |> reverse # keep unique entries
+    rx = r"(^|\n)# time:[^\n]*\n# mode:[^\n]*\n"m
+    @pipe open(REPL.find_hist_file()) |>
+    read |> String |>
+    replace(_, r"\n$" => "") |>           # remove last new line
+    replace(_, r"^\t"m => "") |>          # remove leading tabs
+    split(_, rx, keepempty = false) |>    # split by history records
+    reverse |> unique                     # keep unique entries
 end
 
 """
-inter_fzf(in_str::String)
-run interactive fzf and return selected result, `in_str` should contain `\n`s,
-return selected string
+    inter_fzf(in_str::String, args...)
+
+Run interactive fzf and return selected result, by default `in_str` should use `\n`s as the delimiter,
+return selected string.
+Additional arguments `args` for `fzf` are allowed.
 """
 function inter_fzf(in_str::String, args...)
     fzf_jll.fzf() do exe
         if length(args) == 0
-            return read(pipeline(`$exe`, stdin = IOBuffer(in_str)), String) |> chomp
+            return read(pipeline(Cmd(`$exe`, ignorestatus = true), stdin = IOBuffer(in_str)), String) |> chomp
         else
-            return read(pipeline(`$exe $(join(args, ' '))`, stdin = IOBuffer(in_str)), String) |> chomp
+            return read(pipeline(Cmd(`$exe $(args)`, ignorestatus = true), stdin = IOBuffer(in_str)), String) |> chomp
         end
     end
 end
 
 """
-inter_fzf(ary::AbstractArray)
-run interactive fzf with an array of inputs, return selected string
+    inter_fzf(ary::AbstractArray, args...)
+
+Run interactive fzf with an array of inputs, return selected string.
+Additional arguments `args` for `fzf` are allowed.
 """
 function inter_fzf(ary::AbstractArray, args...)
-    inter_fzf(join(ary, "\n"), args...)
+    inter_fzf(join(ary, '\0'), args...)
 end
 
 end


### PR DESCRIPTION
Further improvements:
* authomaticaly search `repl_history.jl` via `REPL.find_hist_file()`
* use `'\0'` as the delimiter to preserve `'\n'` for multiline commands in history. `fzf` for that use option `--read0`.
* switching to REPL modes in which commands were executed (via https://medium.com/@Jernfrost/exploring-julia-repl-internals-6b19667a7a62 guide)

**Now it works as it should!**

Updated config for `~/.julia/config/startup.jl`
```julia
import REPL
import REPL.LineEdit
import JLFzf
const mykeys = Dict{Any,Any}(
    # primary history search: most recent first
    "^R" => function (mistate, o, c)
        line = JLFzf.inter_fzf(JLFzf.read_repl_hist(), "--read0", "--tiebreak=index");
        JLFzf.insert_history_to_repl(mistate, line)
    end,
    # alternative history search: most relevant first
    "^T" => function (mistate, o, c)
        line = JLFzf.inter_fzf(JLFzf.read_repl_hist(), "--read0");
        JLFzf.insert_history_to_repl(mistate, line)
    end,
)
function customize_keys(repl)
    repl.interface = REPL.setup_interface(repl; extra_repl_keymap = mykeys)
end
atreplinit(customize_keys)
```

Alternative search `<Ctrl-T>` still doesn't work because (as I think) it is not predefined for REPL's search. `<Ctrl-F>` is used/reserved for move to right. This issue requires further investigation, but that will be another issue.