### PR TITLE
Update compat for fzf_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ fzf_jll = "214eeab7-80f7-51ab-84ad-2988db7cef09"
 
 [compat]
 Pipe = "1.3.0"
-fzf_jll = "0.29"
+fzf_jll = "0.29,0.30"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
https://github.com/JuliaBinaryWrappers/fzf_jll.jl released 0.30, not sure why the CompatHelper did not create this PR automatically

I did not test this code or look at the fzf release notes