### PR TITLE
fix jll deprecation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JLFzf"
 uuid = "1019f520-868f-41f5-a6de-eb00f4b6a39c"
 authors = ["Moelf <proton@jling.dev> and contributors"]
-version = "0.1.9"
+version = "0.1.10"
 
 [deps]
 Pipe = "b98c9c47-44ae-5843-9183-064241ee97a0"

--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,11 @@ authors = ["Moelf <proton@jling.dev> and contributors"]
 version = "0.1.10"
 
 [deps]
-Pipe = "b98c9c47-44ae-5843-9183-064241ee97a0"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 fzf_jll = "214eeab7-80f7-51ab-84ad-2988db7cef09"
 
 [compat]
-Pipe = "1.3.0"
 fzf_jll = "0.29, 0.30, 0.34, 0.35, 0.43, 0.49, 0.53, 0.56"
 julia = "1"
 

--- a/src/JLFzf.jl
+++ b/src/JLFzf.jl
@@ -46,11 +46,12 @@ end
 """
     inter_fzf(ary::AbstractArray, args...)
 
-Run interactive fzf with an array of inputs, return selected string.
-Additional arguments `args` for `fzf` are allowed.
+Run fzf with an array of inputs delimited by the null '\\0' character.  Additional
+arguments `args` are passed to `fzf`.  This is expected to be used with the
+`--read0` option.
 """
 function inter_fzf(ary::AbstractArray, args...)
-    inter_fzf(join(ary, '\n'), args...)
+    inter_fzf(join(ary, '\0'), args...)
 end
 
 function edit_insert_and_state_transition(mistate, line, mode)

--- a/src/JLFzf.jl
+++ b/src/JLFzf.jl
@@ -44,7 +44,7 @@ Additional arguments `args` for `fzf` are allowed.
 function inter_fzf(in_str::String, args...)
     if length(args) == 0
         readchomp(
-            pipeline(Cmd(fzf_jll.fzf(), ignorestatus = true), stdin = IOBuffer(in_str)),
+            pipeline(ignorestatus(fzf_jll.fzf()), stdin = IOBuffer(in_str)),
             String,
         )
     else

--- a/src/JLFzf.jl
+++ b/src/JLFzf.jl
@@ -52,7 +52,6 @@ function inter_fzf(in_str::String, args...)
                 ignorestatus(`$(fzf_jll.fzf()) $(args)`),
                 stdin = IOBuffer(in_str),
             ),
-            String,
         )
     end
 end

--- a/src/JLFzf.jl
+++ b/src/JLFzf.jl
@@ -44,7 +44,7 @@ Additional arguments `args` for `fzf` are allowed.
 function inter_fzf(in_str::String, args...)
     if length(args) == 0
         return read(
-            pipeline(Cmd(`$(fzf_jll.fzf())`, ignorestatus = true), stdin = IOBuffer(in_str)),
+            pipeline(Cmd(fzf_jll.fzf(), ignorestatus = true), stdin = IOBuffer(in_str)),
             String,
         ) |> chomp
     else

--- a/src/JLFzf.jl
+++ b/src/JLFzf.jl
@@ -50,7 +50,7 @@ function inter_fzf(in_str::String, args...)
     else
         readchomp(
             pipeline(
-                Cmd(`$(fzf_jll.fzf()) $(args)`, ignorestatus = true),
+                ignorestatus(`$(fzf_jll.fzf()) $(args)`),
                 stdin = IOBuffer(in_str),
             ),
             String,

--- a/src/JLFzf.jl
+++ b/src/JLFzf.jl
@@ -43,18 +43,18 @@ Additional arguments `args` for `fzf` are allowed.
 """
 function inter_fzf(in_str::String, args...)
     if length(args) == 0
-        return read(
+        readchomp(
             pipeline(Cmd(fzf_jll.fzf(), ignorestatus = true), stdin = IOBuffer(in_str)),
             String,
-        ) |> chomp
+        )
     else
-        return read(
+        readchomp(
             pipeline(
                 Cmd(`$(fzf_jll.fzf()) $(args)`, ignorestatus = true),
                 stdin = IOBuffer(in_str),
             ),
             String,
-        ) |> chomp
+        )
     end
 end
 

--- a/src/JLFzf.jl
+++ b/src/JLFzf.jl
@@ -45,7 +45,6 @@ function inter_fzf(in_str::String, args...)
     if length(args) == 0
         readchomp(
             pipeline(ignorestatus(fzf_jll.fzf()), stdin = IOBuffer(in_str)),
-            String,
         )
     else
         readchomp(

--- a/src/JLFzf.jl
+++ b/src/JLFzf.jl
@@ -42,21 +42,19 @@ return selected string.
 Additional arguments `args` for `fzf` are allowed.
 """
 function inter_fzf(in_str::String, args...)
-    fzf_jll.fzf() do exe
-        if length(args) == 0
-            return read(
-                pipeline(Cmd(`$exe`, ignorestatus = true), stdin = IOBuffer(in_str)),
-                String,
-            ) |> chomp
-        else
-            return read(
-                pipeline(
-                    Cmd(`$exe $(args)`, ignorestatus = true),
-                    stdin = IOBuffer(in_str),
-                ),
-                String,
-            ) |> chomp
-        end
+    if length(args) == 0
+        return read(
+            pipeline(Cmd(`$(fzf_jll.fzf())`, ignorestatus = true), stdin = IOBuffer(in_str)),
+            String,
+        ) |> chomp
+    else
+        return read(
+            pipeline(
+                Cmd(`$(fzf_jll.fzf()) $(args)`, ignorestatus = true),
+                stdin = IOBuffer(in_str),
+            ),
+            String,
+        ) |> chomp
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Fzf
+using JLFzf
 using Test
 
 @testset "Fzf.jl" begin


### PR DESCRIPTION
If you run Julia with deprecation warnings on, it will yell at you for using the `do` block form of `fzf_jll.fzf()`.  This was driving me nuts as it would pop up every time I would do reverse search in OhMyREPL.jl.  This fixes it to conform with what is currently recommended by BinaryBuilder.jl.